### PR TITLE
Fix bug where `params` wasn't being found

### DIFF
--- a/R/script_helpers.R
+++ b/R/script_helpers.R
@@ -92,7 +92,7 @@ get_tl_nodes <- function(params_object = NULL){
   
   nodes <- params_object$nodes
   
-  data <- get_tl_data()
+  data <- get_tl_data(params_object=params_object)
   missing_cols <- setdiff(unlist(nodes), colnames(data))
   if(length(missing_cols) > 0){
     stop('Column(s) missing from data: ', missing_cols)


### PR DESCRIPTION
The call to `get_tl_data` here dies with it tries to retrieve `params`
from `parent.frame()`. Normally, the parent frame would be the global
variables in the R Markdown script, but since this is being called
inside `get_tl_nodes`, this isn't the case.